### PR TITLE
Addition of HockeyTweet

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ This is the list of all the projects that have been entered. Names that are cros
 - [ElksInbox](projects/ElksInbox.md) by [@johannesl](https://github.com/johannesl)
 - [Lo1Reader](projects/Lo1Reader.md) by [@ebierman](https://github.com/ebierman)
 - [The Oakland Post](projects/The%20Oakland%20Post.md) by [@aclissold](https://github.com/aclissold)
+- [HockeyTweet](https://github.com/mthistle/HockeyTweetSwift) by [@mthistle](https://github.com/mthistle)

--- a/projects/HockeyTweet.md
+++ b/projects/HockeyTweet.md
@@ -1,0 +1,29 @@
+# HockeyTweet
+
+## Description
+
+Originally written in 2009 as a way to teach myself iOS programming I thought what better way to learn Swift than to dust off this old app and rewrite it in Swift. I don't expect to rerelease the app again since I think the Twitter app landscape, autocompletion, and predictive text have changed so much since the app was first released.
+
+## Project Location
+
+https://github.com/mthistle/HockeyTweetSwift
+
+## Team Members
+
+- Mark Thistle — @mthistle
+
+## Updates
+
+### July 14
+
+- Pushed to github
+
+### July 25
+
+### August 10
+
+### August 25
+
+### September 10
+
+### September 25


### PR DESCRIPTION
Added HockeyTweet port from 2009 Objective-C to 2014 Swift.
